### PR TITLE
Fixed redundant menu items and removed hardcoded strings

### DIFF
--- a/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/MainActivity.java
+++ b/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/MainActivity.java
@@ -27,6 +27,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        setTitle(getResources().getText(R.string.main_activity_title));
 
         //Set up the menu drawer and its items
         mDrawerList = (ListView)findViewById(R.id.navList);mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
@@ -67,7 +68,7 @@ public class MainActivity extends AppCompatActivity {
             /** Called when a drawer has settled in a completely closed state. */
             public void onDrawerClosed(View view) {
                 super.onDrawerClosed(view);
-                getSupportActionBar().setTitle(mActivityTitle);
+                getSupportActionBar().setTitle(R.string.main_activity_title);
                 invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
             }
         };

--- a/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/ProfileViewActivity.java
+++ b/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/ProfileViewActivity.java
@@ -28,7 +28,7 @@ public class ProfileViewActivity extends AppCompatActivity {
 
         //Set up the menu drawer and its items
         mDrawerList = (ListView)findViewById(R.id.navList);mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
-        mActivityTitle = getTitle().toString();
+        setTitle(getResources().getText(R.string.profile_activity_title));
 
         addDrawerItems();
         setupDrawer();
@@ -40,7 +40,7 @@ public class ProfileViewActivity extends AppCompatActivity {
     // Beginning of menu drawer configuration
 
     private void addDrawerItems() {
-        String[] menuPages = { "Profile", "Map", "Standings", "Settings" };
+        String[] menuPages = { "Home", "Map", "Standings", "Settings" };
         mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, menuPages);
         mDrawerList.setAdapter(mAdapter);
 
@@ -65,7 +65,7 @@ public class ProfileViewActivity extends AppCompatActivity {
             /** Called when a drawer has settled in a completely closed state. */
             public void onDrawerClosed(View view) {
                 super.onDrawerClosed(view);
-                getSupportActionBar().setTitle(mActivityTitle);
+                getSupportActionBar().setTitle(R.string.profile_activity_title);
                 invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
             }
         };
@@ -109,7 +109,7 @@ public class ProfileViewActivity extends AppCompatActivity {
         Intent intent;
         switch (position) {
             case 0:
-                intent = new Intent(this, ProfileViewActivity.class);
+                intent = new Intent(this, MainActivity.class);
                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 this.startActivity(intent);
                 break;

--- a/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/StandingsViewActivity.java
+++ b/src/app/src/main/java/edu/calvin/the_b_team/calvinassassingame/StandingsViewActivity.java
@@ -40,13 +40,13 @@ public class StandingsViewActivity extends AppCompatActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
 
-        setTitle("Standings");
+        setTitle(getResources().getText(R.string.standings_activity_title));
 
     }
    // Beginning of menu drawer configuration
 
     private void addDrawerItems() {
-        String[] menuPages = { "Profile", "Map", "Standings", "Settings" };
+        String[] menuPages = { "Home", "Profile", "Map", "Settings" };
         mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, menuPages);
         mDrawerList.setAdapter(mAdapter);
 
@@ -71,7 +71,7 @@ public class StandingsViewActivity extends AppCompatActivity {
             /** Called when a drawer has settled in a completely closed state. */
             public void onDrawerClosed(View view) {
                 super.onDrawerClosed(view);
-                getSupportActionBar().setTitle(mActivityTitle);
+                getSupportActionBar().setTitle(R.string.standings_activity_title);
                 invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
             }
         };
@@ -115,17 +115,17 @@ public class StandingsViewActivity extends AppCompatActivity {
         Intent intent;
         switch (position) {
             case 0:
-                intent = new Intent(this, ProfileViewActivity.class);
+                intent = new Intent(this, MainActivity.class);
                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 this.startActivity(intent);
                 break;
             case 1:
-                intent = new Intent(this, GPSmap.class);
+                intent = new Intent(this, ProfileViewActivity.class);
                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 this.startActivity(intent);
                 break;
             case 2:
-                intent = new Intent(this, StandingsViewActivity.class);
+                intent = new Intent(this, GPSmap.class);
                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 this.startActivity(intent);
                 break;

--- a/src/app/src/main/res/layout/activity_main.xml
+++ b/src/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,7 @@
         android:background="#ffffffff">
 
         <Button
-            android:text="I Killed My Target"
+            android:text="@string/eliniate_button"
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:id="@+id/killedButton"
@@ -76,7 +76,7 @@
             android:layout_alignParentEnd="true" />
 
         <TextView
-            android:text="Target Last Seen:"
+            android:text="@string/last_seen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="24sp"

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -1,12 +1,19 @@
 <resources>
     <string name="app_name">Calvin Assassin Game</string>
-    <string name="main_page_text">This is the initial prototype for The B Team\'s Assassin game.\n\n\nOur awesome members are:\n\nPaige Brinks\nJesse Hulse\nFrank Boye\nNate Bender\nChristiaan Hazlett\n\n\nGet ready this fall... to watch your back.</string>
     <string name="action_settings">Settings</string>
+
+    <!-- Strings related to Menu Drawer -->
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
-    <string name="title_activity_settings">Settings</string>
+
+    <!-- Strings related to Main Activity -->
+    <string name="eliniate_button">I ELIMINATED MY TARGET</string>
+    <string name="last_seen">Target last seen: </string>
+    <string name="main_activity_title">Home</string>
 
     <!-- Strings related to Profile Activity -->
+    <string name="profile_activity_title">Profile</string>
+
     <string name="user_name_label">Player name: </string>
     <string name="user_name">Full Name</string>
     <string name="user_year_label">Player class: </string>
@@ -14,7 +21,11 @@
     <string name="user_home_label">Residence: </string>
     <string name="user_home">Huizenga</string>
 
+    <!-- Strings related to Standings Activity -->
+    <string name="standings_activity_title">Standings</string>
+
     <!-- Strings related to Settings -->
+    <string name="title_activity_settings">Settings</string>
 
     <!-- Example General settings -->
     <string name="pref_header_general">General</string>


### PR DESCRIPTION
I've removed the drawer item for the page it is being accessed from. Prof. Vander Linden mentioned that he "hates clicking a menu item that takes me to where I already am." Plus I removed some hard-coded strings on activities. Itll be nice to have them all in one place. I cleaned up the strings resource file a bit too.
